### PR TITLE
Enable auto manifest updates

### DIFF
--- a/com.strlen.TreeSheets.yml
+++ b/com.strlen.TreeSheets.yml
@@ -20,6 +20,9 @@ modules:
       - type: git
         url: https://github.com/aardappel/treesheets
         commit: 55e3ec441efdd69e06fc8dc926557e9392dbf233
+        x-checker-data:
+          type: git
+          tag-pattern: ^([\d]+)$
       - type: file
         path: com.strlen.TreeSheets.appdata.xml
     post-install:


### PR DESCRIPTION
Closes #47

Easier to show an example. [This is what flathubbot would change on its first run after this PR.](https://github.com/jn64/com.strlen.TreeSheets/commit/2342eb08db63ed3abcdbbea20da961417b443222) 

Apparently it updates appdata as well, but there is currently no way to control that behaviour or add a template with your message "Please refer to the release notes on the GitHub page.", so the changelog will be blank on Flathub.com.

Ideally appdata with changelogs should be maintained upstream, since it is not Flathub/flatpak-specific. Of course, that is not very suitable for treesheets with how releases are (not) managed. I think it's ok to let it be blank.