### PR TITLE
Change x-checker-data to avoid duplicate PRs

### DIFF
--- a/com.strlen.TreeSheets.yml
+++ b/com.strlen.TreeSheets.yml
@@ -20,10 +20,13 @@ modules:
       - type: git
         url: https://github.com/aardappel/treesheets
         commit: 95816241f00ac508e0588d8ed8b90e6bdf732494
-        x-checker-data:
-          type: git
-          tag-pattern: ^([\d]+)$
         tag: '14007388016'
+        x-checker-data:
+          type: json
+          url: https://api.github.com/repos/aardappel/treesheets/releases/latest
+          tag-query: .tag_name
+          version-query: $tag
+          timestamp-query: .published_at
       - type: file
         path: com.strlen.TreeSheets.appdata.xml
     post-install:


### PR DESCRIPTION
The git checker cannot get timestamps of tags (limitation of `git ls-remote`),
so it always uses the current date, resulting in duplicate PRs (and potentially
wrong date in the appdata!).

https://github.com/flathub-infra/flatpak-external-data-checker/issues/154#issuecomment-797268057

JSON checker docs:
https://github.com/flathub-infra/flatpak-external-data-checker?tab=readme-ov-file#json-checker

Example of other packages with this fix:
https://github.com/flathub/com.jgraph.drawio.desktop/commit/b3ebe3899b847faadb34d49390522bcdfb140dbf
https://github.com/flathub/org.ghidra_sre.Ghidra/commit/839898ff683a0bb88feab278c542936ad69e0f64