### PR TITLE
Reduce filesystem permissions

### DIFF
--- a/com.strlen.TreeSheets.yml
+++ b/com.strlen.TreeSheets.yml
@@ -8,7 +8,10 @@ finish-args:
   - --socket=fallback-x11
   - --share=ipc
   - --device=dri
-  - --filesystem=host
+  - --filesystem=home
+  - --filesystem=/mnt
+  - --filesystem=/run/media
+  - --filesystem=/media
 modules:
   - name: TreeSheets
     buildsystem: cmake-ninja


### PR DESCRIPTION
Giving access to entire host (`/` outside flatpak sandbox) is unnecessary. Reduce it to user's home dir and common mount points for removable media (e.g. USB drives).

TS can still access the example docs (`/app/share/doc/TreeSheets/example/...` inside the sandbox) regardless.